### PR TITLE
fix uploading the file

### DIFF
--- a/backend/chat_with_your_data/chat_with_your_data_api/qdrant.py
+++ b/backend/chat_with_your_data/chat_with_your_data_api/qdrant.py
@@ -13,7 +13,7 @@ from .serializers import SectionSerializer
 
 __client = QdrantClient(
     url=os.getenv("QDRANT_URL"),
-    api_key=os.getenv("QDRANT_SECRET"),
+    # api_key=os.getenv("QDRANT_SECRET"),
     prefer_grpc=True
 )
 

--- a/compose.yml
+++ b/compose.yml
@@ -61,7 +61,7 @@ services:
     environment:
       - QDRANT__STORAGE__STORAGE_PATH=/qdrant/storage
       - QDRANT__SERVICE__ENABLE_CORS=true 
-      - QDRANT__SERVICE__API_KEY=${QDRANT_SECRET}
+      # - QDRANT__SERVICE__API_KEY=${QDRANT_SECRET}
 volumes:
   postgres:
     driver: local


### PR DESCRIPTION
The reason file uploads weren't working before was because the Qdrant API key wasn't set. It seems this needs to be configured by the user. In the development environment, we can comment out the Qdrant API key temporarily.

The document vectorization feature is working correctly. I tested it with a PDF file, and the document conversational feature (chatting with the document) is functioning as expected.
![document1](https://github.com/user-attachments/assets/b6901823-1764-4f1c-96c7-079f66e1c01f)
![document2](https://github.com/user-attachments/assets/8a41fccd-4058-44b8-8c82-06d649c15010)
